### PR TITLE
fix(ci/docs): stabilize checks and docs build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,9 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
       
+      - name: Build packages (for workspace references)
+        run: pnpm build
+      
       - name: Type check
         run: pnpm typecheck
 
@@ -52,6 +55,9 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
       
+      - name: Build packages (for workspace references)
+        run: pnpm build
+      
       - name: Lint
         run: pnpm lint
 
@@ -73,6 +79,9 @@ jobs:
       
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
+      
+      - name: Build packages (for workspace references)
+        run: pnpm build
       
       - name: Run tests
         run: pnpm test

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ node_modules
 # Build outputs
 dist
 *.tsbuildinfo
+docs-dist
 
 # Coverage
 coverage

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "typecheck": "pnpm -r typecheck",
     "clean": "pnpm -r clean",
     "ci": "pnpm typecheck && pnpm lint && pnpm test && pnpm build",
-    "docs:api": "typedoc --entryPoints packages/core/src/index.ts --entryPoints packages/react/src/index.ts --out docs-dist/api --plugin typedoc-plugin-markdown",
+    "docs:api": "typedoc --entryPoints packages/core/src/index.ts --entryPoints packages/react/src/index.ts --out docs-dist/api --plugin typedoc-plugin-markdown --tsconfig typedoc.tsconfig.json",
     "docs:build": "mkdir -p docs-dist && cp -r docs/* docs-dist/ && pnpm docs:api",
     "docs:serve": "npx serve docs-dist"
   },

--- a/packages/react/src/useWorkflow.ts
+++ b/packages/react/src/useWorkflow.ts
@@ -1,4 +1,4 @@
-import type { Workflow } from '@workflow-ts/core';
+import type { Workflow, WorkflowRuntime as WorkflowRuntimeType } from '@workflow-ts/core';
 import { createRuntime } from '@workflow-ts/core';
 import { useEffect, useMemo, useRef, useState, useSyncExternalStore } from 'react';
 
@@ -31,8 +31,8 @@ export function useWorkflow<P, S, O, R>(
   onOutputRef.current = onOutput;
 
   // Create runtime once per workflow
-  const [runtime] = useState(() => {
-    return createRuntime(workflow, props, (output) => {
+  const [runtime] = useState<WorkflowRuntimeType<P, S, O, R>>(() => {
+    return createRuntime(workflow, props, (output: O) => {
       onOutputRef.current?.(output);
     });
   });
@@ -111,8 +111,8 @@ export function useWorkflowWithState<P, S, O, R>(
   onOutputRef.current = options.onOutput;
 
   // Create runtime once per workflow
-  const [runtime] = useState(() => {
-    return createRuntime(workflow, options.props, (output) => {
+  const [runtime] = useState<WorkflowRuntimeType<P, S, O, R>>(() => {
+    return createRuntime(workflow, options.props, (output: O) => {
       onOutputRef.current?.(output);
     });
   });

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -4,6 +4,7 @@
     "module": "ESNext",
     "moduleResolution": "bundler",
     "lib": ["ES2022"],
+    "downlevelIteration": true,
     
     "strict": true,
     "noImplicitAny": true,

--- a/typedoc.json
+++ b/typedoc.json
@@ -10,5 +10,6 @@
   "sort": ["source-order"],
   "categorizeByGroup": true,
   "useCodeBlocks": true,
-  "flattenOutput": true
+  "flattenOutputFiles": true,
+  "tsconfig": "typedoc.tsconfig.json"
 }

--- a/typedoc.tsconfig.json
+++ b/typedoc.tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "extends": "./tsconfig.base.json",
+  "compilerOptions": {
+    "target": "ES2022",
+    "moduleResolution": "bundler",
+    "downlevelIteration": true,
+    "baseUrl": ".",
+    "paths": {
+      "@workflow-ts/core": ["packages/core/src"],
+      "@workflow-ts/react": ["packages/react/src"]
+    },
+    "types": ["node", "react"],
+    "typeRoots": [
+      "./packages/react/node_modules/@types",
+      "./packages/core/node_modules/@types",
+      "./node_modules/@types"
+    ],
+    "skipLibCheck": true,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "exactOptionalPropertyTypes": false
+  },
+  "include": ["packages/*/src/**/*.ts", "packages/*/src/**/*.tsx"],
+  "exclude": ["**/test/**", "**/*.test.ts", "**/*.test.tsx"]
+}


### PR DESCRIPTION
## Summary
- Build packages before typecheck/lint/test to fix CI dependency graph
- Fix TypeDoc config for latest option name + dedicated tsconfig
- Add docs-dist to .gitignore
- Tighten React hook runtime typing

## Testing
- pnpm lint
- pnpm typecheck
- pnpm test
- pnpm docs:build

## Merge status
✅ All checks green. Merging now.