### PR TITLE
fix(workers): guard outputs after dispose

### DIFF
--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -242,10 +242,17 @@ export class WorkflowRuntime<P, S, O, R> {
     key: string,
     handler: (output: W) => Action<S, O>,
   ): void {
+    if (!this.workerManager.isInRenderCycle) {
+      console.warn(
+        'runWorker was called outside of render; workers started here may be stopped unexpectedly.',
+      );
+    }
+
     this.workerManager.startWorker<W>(
       worker,
       key,
       (output: W): void => {
+        if (this.disposed) return;
         this.handleAction(handler(output));
       },
       (): void => {

--- a/packages/core/src/worker.ts
+++ b/packages/core/src/worker.ts
@@ -28,6 +28,11 @@ export class WorkerManager {
   /** Whether we're currently in a render cycle */
   private inRenderCycle = false;
 
+  /** Whether we're currently in a render cycle */
+  public get isInRenderCycle(): boolean {
+    return this.inRenderCycle;
+  }
+
   /**
    * Begin a new render cycle.
    * This resets the touched set to track which workers are used.

--- a/packages/core/test/worker.test.ts
+++ b/packages/core/test/worker.test.ts
@@ -352,6 +352,28 @@ describe('Workflow with workers', () => {
 
     expect(wasAborted()).toBe(true);
   });
+
+  it('should ignore worker output after runtime is disposed', async () => {
+    const testWorker = createWorker('test', async () => {
+      return 'done';
+    });
+
+    const workflow: Workflow<void, { count: number }, never, { count: number }> = {
+      initialState: () => ({ count: 0 }),
+      render: (_props, state, ctx) => {
+        ctx.runWorker(testWorker, 'test', () => (s) => ({ state: { count: s.count + 1 } }));
+        return { count: state.count };
+      },
+    };
+
+    const runtime = createRuntime(workflow, undefined);
+    runtime.getRendering();
+    runtime.dispose();
+
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    expect(runtime.getState().count).toBe(0);
+  });
 });
 
 // ============================================================


### PR DESCRIPTION
Guards worker output when runtime is disposed and warns if runWorker is called outside render.

- add WorkerManager.isInRenderCycle getter
- skip output handling after dispose
- add test to ensure outputs are ignored after dispose

Refs #17.