### PR TITLE
feat(snapshot): allow runtime restore

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -36,7 +36,7 @@ interface Workflow<P, S, O, R> {
 - `O` - Output (events to parent, or `never` if none)
 - `R` - Rendering (external representation)
 
-### `createRuntime(workflow, props, onOutput?)`
+### `createRuntime(workflow, props, onOutput?, snapshot?)`
 
 Create a runtime to execute a workflow.
 
@@ -46,6 +46,14 @@ import { createRuntime } from '@workflow-ts/core';
 const runtime = createRuntime(workflow, props, (output) => {
   console.log('Workflow output:', output);
 });
+
+// Restore from snapshot
+const snapshot = runtime.snapshot();
+if (snapshot) {
+  const restored = createRuntime(workflow, props, undefined, snapshot);
+  restored.getRendering();
+  restored.dispose();
+}
 
 // Get current rendering
 const rendering = runtime.getRendering();

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -17,6 +17,8 @@ export interface RuntimeConfig<P, S, O, R> {
   readonly onOutput?: ((output: O) => void) | undefined;
   /** Optional initial state (for testing) */
   readonly initialState?: S | undefined;
+  /** Optional snapshot to restore state from */
+  readonly snapshot?: string | undefined;
 }
 
 /**
@@ -41,7 +43,13 @@ export class WorkflowRuntime<P, S, O, R> {
   private disposed = false;
 
   constructor(private readonly config: RuntimeConfig<P, S, O, R>) {
-    this.state = config.initialState ?? config.workflow.initialState(config.props);
+    const restoredState =
+      config.snapshot !== undefined
+        ? (config.workflow.restore?.(config.snapshot) ??
+            config.workflow.initialState(config.props, config.snapshot))
+        : undefined;
+
+    this.state = config.initialState ?? restoredState ?? config.workflow.initialState(config.props);
     this.currentProps = config.props;
   }
 
@@ -308,6 +316,7 @@ export function createRuntime<P, S, O, R>(
   workflow: Workflow<P, S, O, R>,
   props: P,
   onOutput?: (output: O) => void,
+  snapshot?: string,
 ): WorkflowRuntime<P, S, O, R> {
-  return new WorkflowRuntime({ workflow, props, onOutput });
+  return new WorkflowRuntime({ workflow, props, onOutput, snapshot });
 }

--- a/packages/core/test/runtime.test.ts
+++ b/packages/core/test/runtime.test.ts
@@ -648,6 +648,43 @@ describe('Snapshot/restore workflow state', () => {
     runtime.dispose();
   });
 
+  it('should restore state from snapshot when provided', () => {
+    const runtime = createRuntime(
+      snapshotWorkflow,
+      undefined,
+      undefined,
+      '{"count":7,"name":"restored"}',
+    );
+
+    expect(runtime.getState()).toEqual({ count: 7, name: 'restored' });
+    expect(runtime.getRendering().display).toBe('restored: 7');
+
+    runtime.dispose();
+  });
+
+  it('should prefer restore over initialState when snapshot is provided', () => {
+    const workflow: Workflow<void, SnapshotState, never, SnapshotRendering> = {
+      initialState: () => ({ count: 0, name: 'initial' }),
+      restore: (snapshot) => {
+        const parsed = JSON.parse(snapshot) as SnapshotState;
+        return { count: parsed.count + 1, name: `${parsed.name}-restored` };
+      },
+      render: (_props, state) => ({
+        display: `${state.name}: ${state.count}`,
+        count: state.count,
+        name: state.name,
+      }),
+      snapshot: (state) => JSON.stringify(state),
+    };
+
+    const runtime = createRuntime(workflow, undefined, undefined, '{"count":2,"name":"base"}');
+
+    expect(runtime.getState()).toEqual({ count: 3, name: 'base-restored' });
+    expect(runtime.getRendering().display).toBe('base-restored: 3');
+
+    runtime.dispose();
+  });
+
   it('should use jsonSnapshot utility', () => {
     const { snapshot, restore } = jsonSnapshot<{ count: number }>();
     


### PR DESCRIPTION
Adds snapshot restore support to createRuntime with restore precedence.

- createRuntime now accepts optional snapshot param
- workflow.restore(snapshot) preferred; fallback to initialState(props, snapshot)
- docs updated + tests added

Refs #17.