### PR TITLE
fix(workers): tighten abort handling

### DIFF
--- a/packages/core/src/worker.ts
+++ b/packages/core/src/worker.ts
@@ -200,6 +200,9 @@ export function createWorker<T>(
  */
 export function fromPromise<T>(key: string, factory: () => Promise<T>): Worker<T> {
   return createWorker(key, async (signal: AbortSignal): Promise<T> => {
+    if (signal.aborted) {
+      throw new DOMException('Aborted', 'AbortError');
+    }
     const result = await factory();
     if (signal.aborted) {
       throw new DOMException('Aborted', 'AbortError');
@@ -241,6 +244,10 @@ export function fetchWorker<T>(key: string, url: string, options?: RequestInit):
  */
 export function debounceWorker<T>(key: string, worker: Worker<T>, delayMs: number): Worker<T> {
   return createWorker(key, async (signal: AbortSignal): Promise<T> => {
+    if (signal.aborted) {
+      throw new DOMException('Aborted', 'AbortError');
+    }
+
     await new Promise<void>((resolve) => {
       const timeout = setTimeout(resolve, delayMs);
       signal.addEventListener('abort', () => {

--- a/packages/core/test/worker.test.ts
+++ b/packages/core/test/worker.test.ts
@@ -3,6 +3,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   createRuntime,
   createWorker,
+  debounceWorker,
+  fromPromise,
   type Workflow,
   type Worker,
 } from '../src';
@@ -478,5 +480,27 @@ describe('AbortSignal integration', () => {
 
     // Worker should have been stopped without error
     runtime.dispose();
+  });
+
+  it('should abort fromPromise before awaiting factory when already aborted', async () => {
+    const worker = fromPromise('test', async () => {
+      throw new Error('should not run');
+    });
+
+    const controller = new AbortController();
+    controller.abort();
+
+    await expect(worker.run(controller.signal)).rejects.toThrow('Aborted');
+  });
+
+  it('should abort debounced worker before starting inner worker', async () => {
+    const inner = createWorker('inner', async () => 'done');
+    const debounced = debounceWorker('debounced', inner, 50);
+
+    const controller = new AbortController();
+    const promise = debounced.run(controller.signal);
+    controller.abort();
+
+    await expect(promise).rejects.toThrow('Aborted');
   });
 });


### PR DESCRIPTION
Fixes abort timing in fromPromise and debounceWorker.

- check signal.aborted before awaiting factory
- check signal.aborted before delay and before inner worker run
- add tests for both cases

Refs #24, #25.