### PR TITLE
chore(react): keep tests disabled pending vitest hang

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -31,7 +31,7 @@
   "scripts": {
     "build": "tsup src/index.ts --format cjs,esm --dts --clean",
     "typecheck": "tsc --noEmit",
-    "test": "echo 'Tests temporarily disabled - see issue #1'",
+    "test": "echo "Tests temporarily disabled - see issue #29"",
     "test:run": "vitest run",
     "test:watch": "vitest",
     "clean": "rm -rf dist *.tsbuildinfo"


### PR DESCRIPTION
Keeps @workflow-ts/react tests disabled for now. I attempted to re-enable and run Vitest with happy-dom/jsdom/--dom, single worker, no parallelism, no isolation, but Vitest 4.0.18 hangs at RUN and never executes tests (eventually "Timeout terminating forks worker"). environment=node runs but fails (document is not defined). See issue #29 comment for details. This PR just preserves the disabled test script to keep CI green.