### PR TITLE
chore: release v0.1.3 (security patches)

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@workflow-ts/core",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Core workflow runtime and types",
   "keywords": [
     "workflow",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@workflow-ts/react",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "React bindings for workflow-ts",
   "keywords": [
     "workflow",


### PR DESCRIPTION
Bumps `@workflow-ts/core` and `@workflow-ts/react` to v0.1.3. Includes security vulnerability fixes and dependency updates since v0.1.2.

Triggering the release workflow after merge will publish to npm and create the GitHub release tag.