### PR TITLE
chore: configure eslint to ignore underscore-prefixed unused params

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -72,7 +72,13 @@ const tsConfig = {
     '@typescript-eslint/no-confusing-void-expression': 'warn',
     '@typescript-eslint/no-empty-function': 'warn',
     '@typescript-eslint/require-await': 'warn',
-    '@typescript-eslint/no-unused-vars': 'warn',
+    '@typescript-eslint/no-unused-vars': [
+      'warn',
+      {
+        argsIgnorePattern: '^_',
+        varsIgnorePattern: '^_',
+      },
+    ],
 
     // Import rules
     'import/order': [


### PR DESCRIPTION
Aligns ESLint with TypeScript's `noUnusedParameters` behavior, which already ignores parameters prefixed with `\_`. This removes false-positive warnings for intentional unused parameters like `\_O` and `\_R` in generic type signatures.