### PR TITLE
fix: resolve lint warnings in persistRuntime

### DIFF
--- a/packages/core/src/persistRuntime.ts
+++ b/packages/core/src/persistRuntime.ts
@@ -150,7 +150,7 @@ const createErrorReporter = (
 };
 
 const createHydrateAction = <S, O>(state: S): Action<S, O> => {
-  return named(HYDRATE_ACTION_NAME, (_prevState: S) => ({ state }));
+  return named(HYDRATE_ACTION_NAME, (_: S) => ({ state }));
 };
 
 const createPersistInterceptor = <S, O>(
@@ -365,11 +365,8 @@ const createPersistRuntimeInternals = <P, S, O, R>(
     pendingSnapshot = snapshot;
 
     if (debounceMs === 0) {
-      const nextSnapshot = pendingSnapshot;
       pendingSnapshot = undefined;
-      if (nextSnapshot !== undefined) {
-        enqueuePersist(nextSnapshot);
-      }
+      enqueuePersist(snapshot);
       return;
     }
 
@@ -516,13 +513,13 @@ export function createPersistedRuntime<P, S, O, R>(
   return internals.runtime;
 }
 
-const createBlockingRuntime = async <P, S, O, R>(
+const createBlockingRuntime = <P, S, O, R>(
   workflow: Workflow<P, S, O, R>,
   props: P,
   config: PersistConfig<P, S, O, R>,
   reportError: (error: unknown, context: PersistErrorContext) => void,
   storedValue: string,
-): Promise<WorkflowRuntime<P, S, O, R>> => {
+): WorkflowRuntime<P, S, O, R> => {
   const asyncStorage = toAsyncStorage(config.storage);
   const deserializeState = config.deserialize;
 


### PR DESCRIPTION
Fixes three ESLint warnings in `packages/core/src/persistRuntime.ts`:\n\n1. **no-unused-vars**: Remove unused parameter name `\_prevState` in `createHydrateAction` reducer.\n2. **no-unnecessary-condition**: Eliminate redundant `undefined` check when `debounceMs === 0`; `snapshot` is already typed as `string`.\n3. **require-await**: Remove unnecessary `async` keyword from `createBlockingRuntime` since it performs no await operations.