### PR TITLE
refactor: use nullish coalescing assignment in usePersistedWorkflow

### DIFF
--- a/packages/react/src/usePersistedWorkflow.ts
+++ b/packages/react/src/usePersistedWorkflow.ts
@@ -173,9 +173,7 @@ export function usePersistedWorkflow<P extends AllowedProp, S, O, R>(
   const shouldBeActiveRef = useRef(true);
 
   const persistenceStoreRef = useRef<PersistenceStore | null>(null);
-  if (persistenceStoreRef.current === null) {
-    persistenceStoreRef.current = createPersistenceStore();
-  }
+  persistenceStoreRef.current ??= createPersistenceStore();
   const persistenceStore = persistenceStoreRef.current;
   const runtimeTokenRef = useRef(0);
   const isCreatingRuntimeRef = useRef(false);


### PR DESCRIPTION
Replace the explicit null-check-and-assign block with the `??=` operator for initializing the persistence store ref. This is simpler and aligns with the `@typescript-eslint/prefer-nullish-coalescing` rule.