### PR TITLE
feat(react): add selector support to useWorkflow

### DIFF
--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -7,6 +7,7 @@ export type {
   AllowedProp,
   AllowedPropPrimitive,
   AllowedTypedArray,
+  UseWorkflowHookOptions,
   UseWorkflowOptions,
   UseWorkflowResult,
 } from './useWorkflow';

--- a/packages/react/src/useWorkflow.ts
+++ b/packages/react/src/useWorkflow.ts
@@ -35,19 +35,49 @@ export type { AllowedProp, AllowedPropPrimitive, AllowedTypedArray };
  * );
  * ```
  */
-export type UseWorkflowHookOptions<O> = WorkflowRuntimeOptions<O>;
+export interface UseWorkflowHookOptions<O> extends WorkflowRuntimeOptions<O> {
+  /** Custom comparator for selector values. Defaults to Object.is */
+  compare?: (a: unknown, b: unknown) => boolean;
+}
+
+const empty = Symbol('empty');
 
 export function useWorkflow<P extends AllowedProp, S, O, R>(
   workflow: Workflow<P, S, O, R>,
   props: P,
   onOutput?: (output: O) => void,
   options?: UseWorkflowHookOptions<O>,
-): R {
+): R;
+
+export function useWorkflow<P extends AllowedProp, S, O, R, T>(
+  workflow: Workflow<P, S, O, R>,
+  props: P,
+  onOutput: ((output: O) => void) | undefined,
+  options: UseWorkflowHookOptions<O> & { select: (rendering: R) => T },
+): T;
+
+export function useWorkflow<P extends AllowedProp, S, O, R>(
+  workflow: Workflow<P, S, O, R>,
+  props: P,
+  onOutput?: (output: O) => void,
+  options?: UseWorkflowHookOptions<O> & { select?: (rendering: R) => unknown },
+): unknown {
+  const select = options?.select;
+  const compare = options?.compare ?? Object.is;
   const lastRenderingRef = useRef<R | null>(null);
+  const lastSelectedSnapshotRef = useRef<unknown>(empty);
+  const lastSelectedNotifyRef = useRef<unknown>(empty);
   const runtimeRef = useRef<WorkflowRuntime<P, S, O, R> | null>(null);
-  const storeRuntimeState = useCallback((runtimeToStore: WorkflowRuntime<P, S, O, R>) => {
-    lastRenderingRef.current = runtimeToStore.getRendering();
-  }, []);
+  const storeRuntimeState = useCallback(
+    (runtimeToStore: WorkflowRuntime<P, S, O, R>) => {
+      const rendering = runtimeToStore.getRendering();
+      lastRenderingRef.current = rendering;
+      if (select !== undefined) {
+        lastSelectedNotifyRef.current = select(rendering);
+      }
+    },
+    [select],
+  );
   const { runtime, shouldBeActive } = useManagedWorkflowRuntime({
     workflow,
     props,
@@ -72,32 +102,60 @@ export function useWorkflow<P extends AllowedProp, S, O, R>(
       if (!shouldBeActive || runtime === null || runtime.isDisposed()) {
         return () => undefined;
       }
-      return runtime.subscribe(listener);
+      if (select === undefined) {
+        return runtime.subscribe(listener);
+      }
+      // Selector path: only notify when selected value changes
+      const currentRendering = runtime.getRendering();
+      lastSelectedNotifyRef.current = select(currentRendering);
+      return runtime.subscribe((rendering) => {
+        const selected = select(rendering);
+        if (!compare(selected, lastSelectedNotifyRef.current)) {
+          lastSelectedNotifyRef.current = selected;
+          listener();
+        }
+      });
     },
-    [runtime, shouldBeActive],
+    [runtime, shouldBeActive, select, compare],
   );
   const getRenderingSnapshot = useCallback(() => {
-    if (shouldBeActive) {
-      if (runtime === null || runtime.isDisposed()) {
-        throw new Error('Workflow runtime is not available');
+    const getFullRendering = (): R => {
+      if (shouldBeActive) {
+        if (runtime === null || runtime.isDisposed()) {
+          throw new Error('Workflow runtime is not available');
+        }
+        const rendering = runtime.getRendering();
+        lastRenderingRef.current = rendering;
+        return rendering;
       }
-      const rendering = runtime.getRendering();
-      lastRenderingRef.current = rendering;
-      return rendering;
-    }
 
-    if (runtime !== null && !runtime.isDisposed()) {
-      const rendering = runtime.getRendering();
-      lastRenderingRef.current = rendering;
-      return rendering;
-    }
+      if (runtime !== null && !runtime.isDisposed()) {
+        const rendering = runtime.getRendering();
+        lastRenderingRef.current = rendering;
+        return rendering;
+      }
 
-    if (lastRenderingRef.current !== null) {
-      return lastRenderingRef.current;
-    }
+      if (lastRenderingRef.current !== null) {
+        return lastRenderingRef.current;
+      }
 
-    throw new Error('Workflow rendering is not available while inactive');
-  }, [runtime, shouldBeActive]);
+      throw new Error('Workflow rendering is not available while inactive');
+    };
+
+    const rendering = getFullRendering();
+    if (select !== undefined) {
+      const selected = select(rendering);
+      if (
+        lastSelectedSnapshotRef.current !== empty &&
+        compare(selected, lastSelectedSnapshotRef.current)
+      ) {
+        return lastSelectedSnapshotRef.current;
+      }
+      lastSelectedSnapshotRef.current = selected;
+      return selected;
+    }
+    return rendering;
+  }, [runtime, shouldBeActive, select, compare]);
 
   // Subscribe to rendering changes
   return useSyncExternalStore(subscribe, getRenderingSnapshot, getRenderingSnapshot);

--- a/packages/react/test/useWorkflow.test.ts
+++ b/packages/react/test/useWorkflow.test.ts
@@ -1,6 +1,6 @@
 import { renderHook, act } from '@testing-library/react';
 import { createWorker, WorkflowRuntime, type Workflow } from '@workflow-ts/core';
-import { StrictMode } from 'react';
+import { StrictMode, useCallback } from 'react';
 import { describe, expect, it, vi } from 'vitest';
 
 import type { AllowedProp } from '../src/useWorkflow';
@@ -190,6 +190,36 @@ const workerPolicyWorkflow: Workflow<void, WorkerPolicyState, never, WorkerPolic
     }
     return { value: state.value };
   },
+};
+
+// ============================================================
+// Selector Test Types
+// ============================================================
+
+interface SelectorState {
+  readonly count: number;
+  readonly name: string;
+}
+
+interface SelectorRendering {
+  readonly count: number;
+  readonly name: string;
+  readonly onIncrement: () => void;
+  readonly onRename: () => void;
+}
+
+const selectorWorkflow: Workflow<void, SelectorState, never, SelectorRendering> = {
+  initialState: () => ({ count: 0, name: 'initial' }),
+  render: (_props, state, ctx): SelectorRendering => ({
+    count: state.count,
+    name: state.name,
+    onIncrement: () => {
+      ctx.actionSink.send((s) => ({ state: { ...s, count: s.count + 1 } }));
+    },
+    onRename: () => {
+      ctx.actionSink.send((s) => ({ state: { ...s, name: 'updated' } }));
+    },
+  }),
 };
 
 // ============================================================
@@ -1279,6 +1309,115 @@ describe('useWorkflow', () => {
     });
 
     expect(result.current.value).toBe(1);
+
+    unmount();
+  });
+
+  it('should return selected value', () => {
+    const { result, unmount } = renderHook(() =>
+      useWorkflow(selectorWorkflow, undefined, undefined, { select: (r) => r.count }),
+    );
+
+    expect(result.current).toBe(0);
+
+    unmount();
+  });
+
+  it('should not re-render when unselected value changes', () => {
+    const actionsRef = { current: { onIncrement: () => {}, onRename: () => {} } };
+
+    let renderCount = 0;
+    const { result, unmount } = renderHook(() => {
+      renderCount++;
+      return useWorkflow(selectorWorkflow, undefined, undefined, {
+        select: useCallback((r: SelectorRendering) => {
+          actionsRef.current = { onIncrement: r.onIncrement, onRename: r.onRename };
+          return r.count;
+        }, []),
+      });
+    });
+
+    expect(result.current).toBe(0);
+    expect(renderCount).toBe(1);
+
+    act(() => {
+      actionsRef.current.onRename();
+    });
+
+    expect(renderCount).toBe(1);
+    expect(result.current).toBe(0);
+
+    unmount();
+  });
+
+  it('should re-render when selected value changes', () => {
+    const actionsRef = { current: { onIncrement: () => {}, onRename: () => {} } };
+
+    let renderCount = 0;
+    const { result, unmount } = renderHook(() => {
+      renderCount++;
+      return useWorkflow(selectorWorkflow, undefined, undefined, {
+        select: useCallback((r: SelectorRendering) => {
+          actionsRef.current = { onIncrement: r.onIncrement, onRename: r.onRename };
+          return r.count;
+        }, []),
+      });
+    });
+
+    expect(result.current).toBe(0);
+    expect(renderCount).toBe(1);
+
+    act(() => {
+      actionsRef.current.onIncrement();
+    });
+
+    expect(renderCount).toBe(2);
+    expect(result.current).toBe(1);
+
+    act(() => {
+      actionsRef.current.onIncrement();
+    });
+
+    expect(renderCount).toBe(3);
+    expect(result.current).toBe(2);
+
+    unmount();
+  });
+
+  it('should support custom comparator', () => {
+    const actionsRef = { current: { onIncrement: () => {}, onRename: () => {} } };
+
+    let renderCount = 0;
+    const { result, unmount } = renderHook(() => {
+      renderCount++;
+      return useWorkflow(selectorWorkflow, undefined, undefined, {
+        select: useCallback((r: SelectorRendering) => {
+          actionsRef.current = { onIncrement: r.onIncrement, onRename: r.onRename };
+          return { count: r.count };
+        }, []),
+        compare: (a, b) =>
+          (a as { count: number }).count === (b as { count: number }).count,
+      });
+    });
+
+    expect(result.current).toEqual({ count: 0 });
+    expect(renderCount).toBe(1);
+
+    // Rename doesn't change count — comparator should treat as equal
+    act(() => {
+      actionsRef.current.onRename();
+    });
+
+    expect(renderCount).toBe(1);
+    expect(result.current).toEqual({ count: 0 });
+
+    // Increment changes count — should re-render
+    act(() => {
+      actionsRef.current.onIncrement();
+    });
+
+    expect(renderCount).toBe(2);
+    expect(result.current).toEqual({ count: 1 });
 
     unmount();
   });


### PR DESCRIPTION
Adds opt-in rendering selectors to `useWorkflow` so components only re-render when the selected slice changes.

### Changes
- Add `select` and `compare` options to `UseWorkflowHookOptions`
- Add overloaded type signatures for inferred selector return types
- Memoize selected snapshots internally to avoid React tearing / infinite loops when selectors return new objects
- Add tests for basic selection, re-render skipping, and custom comparators

### Usage
```tsx
const count = useWorkflow(counterWorkflow, undefined, undefined, {
  select: (r) => r.count,
});
```

### Roadmap
Closes roadmap task: `p0-selectors-memoization`